### PR TITLE
Fixed unscrollable item on iOS

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectItemDetails.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectItemDetails.xaml
@@ -373,18 +373,17 @@
 					Margin="16,22" />
 		</Grid>
 
-		<Grid Visibility="{Binding ChildrenWorkItems.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-			  Grid.Row="1">
+		<ScrollViewer Visibility="{Binding ChildrenWorkItems.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+					  Grid.Row="1">
+			<Grid>
+				<Grid Visibility="{Binding WorkItem.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+					  Background="{StaticResource Color02Brush}">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="*" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
 
-			<Grid Visibility="{Binding WorkItem.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-				  Background="{StaticResource Color02Brush}">
-				<Grid.RowDefinitions>
-					<RowDefinition Height="*" />
-					<RowDefinition Height="Auto" />
-				</Grid.RowDefinitions>
-
-				<!-- Content -->
-				<ScrollViewer>
+					<!-- Content -->
 					<Grid Visibility="{Binding ChildrenWorkItems.IsSuccess, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed, TargetNullValue=Collapsed}"
 						  Background="{StaticResource Color02Brush}">
 						<Grid.RowDefinitions>
@@ -418,38 +417,38 @@
 											 ContentTemplate="{StaticResource ListFooterTemplate}"
 											 Grid.Row="2" />
 					</Grid>
-				</ScrollViewer>
+				</Grid>
+
+				<!-- Double click back button tutorial -->
+				<Grid Visibility="{Binding ShowDoubleBackTip, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+					  Background="{StaticResource Color02Brush}"
+					  BorderBrush="{StaticResource Color07Brush}"
+					  BorderThickness="1"
+					  HorizontalAlignment="Center"
+					  VerticalAlignment="Top"
+					  MaxWidth="340"
+					  CornerRadius="8"
+					  toolkit:UIElementExtensions.Elevation="10"
+					  Margin="16"
+					  Grid.Row="1">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+
+					<!-- Message -->
+					<TextBlock Text="To go directly back to the project page, double tap on the back icon."
+							   Style="{StaticResource Typo05}"
+							   Margin="16,16,0,16" />
+
+					<!-- Ok Button -->
+					<Button Style="{StaticResource OkButtonStyle}"
+							Command="{Binding HideDoubleBackTip}"
+							VerticalAlignment="Center"
+							Grid.Column="1"
+							android:Margin="0,0,12,0" />
+				</Grid>
 			</Grid>
-
-			<!-- Double click back button tutorial -->
-			<Grid Visibility="{Binding ShowDoubleBackTip, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-				  Background="{StaticResource Color02Brush}"
-				  BorderBrush="{StaticResource Color07Brush}"
-				  BorderThickness="1"
-				  HorizontalAlignment="Center"
-				  VerticalAlignment="Top"
-				  MaxWidth="340"
-				  CornerRadius="8"
-				  toolkit:UIElementExtensions.Elevation="10"
-				  Margin="16"
-				  Grid.Row="1">
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="*" />
-					<ColumnDefinition Width="Auto" />
-				</Grid.ColumnDefinitions>
-
-				<!-- Message -->
-				<TextBlock Text="To go directly back to the project page, double tap on the back icon."
-						   Style="{StaticResource Typo05}"
-						   Margin="16,16,0,16" />
-
-				<!-- Ok Button -->
-				<Button Style="{StaticResource OkButtonStyle}"
-						Command="{Binding HideDoubleBackTip}"
-						VerticalAlignment="Center"
-						Grid.Column="1"
-						android:Margin="0,0,12,0" />
-			</Grid>
-		</Grid>
+		</ScrollViewer>
 	</Grid>
 </Page>


### PR DESCRIPTION
Moved higher in view's node hierarchy the scrollviewer to avoid bounce on iOS due to grid's rows size calculation. 