### PR TITLE
Added linker exclusions for Android

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Droid/LinkerExclusions.xml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Droid/LinkerExclusions.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<assembly fullname="Newtonsoft.Json"/>
+</linker>

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Droid/Uno.AzureDevOps.Droid.csproj
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Droid/Uno.AzureDevOps.Droid.csproj
@@ -151,6 +151,9 @@
     <AndroidResource Include="Resources\drawable-xhdpi\more.png" />
     <AndroidResource Include="Resources\drawable-xxhdpi\more.png" />
     <AndroidResource Include="Resources\drawable-xxxhdpi\more.png" />
+    <LinkDescription Include="LinkerExclusions.xml">
+      <SubType>Designer</SubType>
+    </LinkDescription>
     <Content Include="Resources\values\Colors.xml">
       <SubType>Designer</SubType>
     </Content>


### PR DESCRIPTION
- Added a LinkerExclusions file to Android project to exclude Newtonsoft assembly from linking (same as iOS & WASM) : fix error on WorkItems listview

