### PR TITLE
Fixed logout issue when login & logout two different users on iOS

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/UnoWebView/UnoWebView.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/UnoWebView/UnoWebView.cs
@@ -16,8 +16,6 @@ namespace Uno.AzureDevOps.Views.Controls
 		{
 			DefaultStyleKey = nameof(UnoWebView);
 
-			SetWebView();
-
 			Loaded += OnLoaded;
 			Unloaded += OnUnloaded;
 		}
@@ -39,12 +37,7 @@ namespace Uno.AzureDevOps.Views.Controls
 			"SourceUri",
 			typeof(Uri),
 			typeof(UnoWebView),
-			new PropertyMetadata(default(Uri), (d, e) => OnSourceUriChanged((UnoWebView)d)));
-
-		private static void OnSourceUriChanged(UnoWebView webView)
-		{
-			webView.SetWebView();
-		}
+			new PropertyMetadata(default(Uri)));
 
 		public Uri NavigatedUri
 		{
@@ -100,7 +93,7 @@ namespace Uno.AzureDevOps.Views.Controls
 
 		private WebView GetDefaultWebView()
 		{
-			if (_webView != null && !_isFirstNavigation)
+			if (_webView != null)
 			{
 				return _webView;
 			}
@@ -133,7 +126,10 @@ namespace Uno.AzureDevOps.Views.Controls
 					ClearCacheAndCookies();
 				}
 			}
-
+#if __IOS__
+			// Needed as webview keeps for unknown reason the token, delete cookies each time avoid this behavior
+			ClearCacheAndCookies();
+#endif
 			NavigatedUri = args.Uri;
 		}
 

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/UnoWebView/UnoWebView.iOS.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/UnoWebView/UnoWebView.iOS.cs
@@ -1,5 +1,4 @@
 ﻿#if __IOS__
-using System;
 using Foundation;
 using UIKit;
 using WebKit;
@@ -7,10 +6,18 @@ using WebKit;
 namespace Uno.AzureDevOps.Views.Controls
 {
 	partial class UnoWebView
-    {
+	{
+
 		partial void ClearCacheAndCookies()
 		{
 			NSUrlCache.SharedCache.RemoveAllCachedResponses();
+
+			// Calling both methods as there are cookies in both SharedStorage & HttpCookieStore even if ios >= 11
+			var cookieStorage = NSHttpCookieStorage.SharedStorage;
+			foreach (var cookie in cookieStorage.Cookies)
+			{
+				cookieStorage.DeleteCookie(cookie);
+			}
 
 			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
 			{
@@ -21,13 +28,6 @@ namespace Uno.AzureDevOps.Views.Controls
 						WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.DeleteCookie(cookie, null);
 					}
 				});
-			}
-			else
-			{
-				foreach (var cookie in NSHttpCookieStorage.SharedStorage.Cookies)
-				{
-					NSHttpCookieStorage.SharedStorage.DeleteCookie(cookie);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes (partially) the issue of looping in a login flow when logging out after being connected with two different accounts. 

Webview is having a weird behavior on iOS and seems to keep data (token). **WKWebView** and its DataStore holds cookies but also **NSHttpCookieStorage**. So even on iOS >= 11 we need to call both methods to be sure every cookies are deleted.  

- Removed uncessary calls that caused duplication of webview instances.
- Removed uncessary callback method on SourceUri that was also introducing this issue
- Added a call to clear cookies for iOS only each time OnNavigationStarting is called 

Step tried : Remove all caches localStorage, sessionStorage, and WebSQL/IndexedDB ... but the token still remains. Also, there seems to be a lot of issues with cookies storage on iOS or with Azure webviews login. One way to avoid this workaround would be to re create WKProcessPool but I don't see how to do this in our current implementation (and not sure this will fix the error, that's just some SO's users ideas) 

> we force the WKWebView to flush its internal data, including cookies, by replacing its WKProcessPool with a new one

[Link1](https://stackoverflow.com/questions/55226617/ios-adal-auto-sign-in-after-sign-out)
[Link2](https://forums.xamarin.com/discussion/72085/how-to-logout-using-azure-adal)
[Link3](https://github.com/xamarin/Xamarin.Auth/issues/204)
[Link4](https://stackoverflow.com/questions/39772007/wkwebview-persistent-storage-of-cookies) 
[Link5](https://winsmarts.com/adal-ios-fully-sign-out-a-user-edb7bf6707cc)