### PR TITLE
Fixed list project/organization pages reloads and listview position

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/OrganizationListPageViewModel.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/OrganizationListPageViewModel.cs
@@ -50,7 +50,11 @@ namespace Uno.AzureDevOps.Presentation
 
 		public void OnNavigatedTo()
 		{
-			Organizations = new TaskNotifier<List<AccountData>>(GetOrganizations());
+			// Check IsFaulted too here as user might come from ProfilePage
+			if (Organizations == null || Organizations.IsFaulted)
+			{
+				Organizations = new TaskNotifier<List<AccountData>>(GetOrganizations());
+			}
 		}
 
 		public void NavigateToProjectListPage(AccountData account)

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/ProjectListPageViewModel.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/ProjectListPageViewModel.cs
@@ -29,8 +29,6 @@ namespace Uno.AzureDevOps.Presentation
 
 			ToProjectPage = new RelayCommand<TeamProjectReference>(project => _navigationService.ToProjectPage(project));
 
-			Projects = new TaskNotifier<List<TeamProjectReference>>(Task.FromResult(new List<TeamProjectReference>()));
-
 			ReloadPage = new RelayCommand(() => Projects = new TaskNotifier<List<TeamProjectReference>>(GetProjects()));
 
 			ToProfilePage = new RelayCommand(() => _navigationService.ToProfilePage());
@@ -60,12 +58,14 @@ namespace Uno.AzureDevOps.Presentation
 
 			_vstsRepository.SetVSTSAccount(_account.AccountName);
 
-			Projects = new TaskNotifier<List<TeamProjectReference>>(GetProjects());
+			if (Projects == null)
+			{
+				Projects = new TaskNotifier<List<TeamProjectReference>>(GetProjects());
+			}
 		}
 
 		public void NavigateToProjectPage(TeamProjectReference project)
 		{
-			Projects = null;
 			ToProjectPage.Execute(project);
 		}
 

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/OrganizationListPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/OrganizationListPage.xaml
@@ -35,7 +35,7 @@
 
 					<!-- Profile Button -->
 					<AppBarButton Style="{StaticResource UserProfileButtonStyle}"
-								  Command="{Binding ToProfilePage}"/>
+								  Command="{Binding ToProfilePage}" />
 				</CommandBar.PrimaryCommands>
 			</CommandBar>
 
@@ -48,7 +48,7 @@
 							HorizontalAlignment="Center">
 
 					<!-- Progress Ring -->
-					<ProgressRing IsActive="{Binding Organizations.IsExecuting}"
+					<ProgressRing IsActive="True"
 								  Foreground="{StaticResource Color03Brush}"
 								  Height="20"
 								  Width="20"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml
@@ -40,7 +40,7 @@
 						HorizontalAlignment="Center">
 
 				<!-- Progress Ring -->
-				<ProgressRing IsActive="{Binding UserProfile.IsExecuting}"
+				<ProgressRing IsActive="True"
 							  Foreground="{StaticResource Color03Brush}"
 							  Height="20"
 							  Width="20"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectItemDetails.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectItemDetails.xaml
@@ -317,7 +317,7 @@
 						HorizontalAlignment="Center">
 
 				<!-- Progress Ring -->
-				<ProgressRing IsActive="{Binding ChildrenWorkItems.IsExecuting}"
+				<ProgressRing IsActive="True"
 							  Foreground="{StaticResource Color03Brush}"
 							  Height="20"
 							  Width="20"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectListPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectListPage.xaml
@@ -97,7 +97,7 @@
 							HorizontalAlignment="Center">
 
 					<!-- Progress Ring -->
-					<ProgressRing IsActive="{Binding Projects.IsExecuting}"
+					<ProgressRing IsActive="True"
 								  Foreground="{StaticResource Color03Brush}"
 								  Height="20"
 								  Width="20"
@@ -147,7 +147,7 @@
 								HorizontalAlignment="Left"
 								Margin="16,16,0,12"
 								Grid.Row="0" />
-				
+
 				<!-- Recent Project list -->
 				<ListView ItemsSource="{Binding Projects.Result}"
 						  ItemTemplate="{StaticResource ProjectItemTemplate}"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectPage.xaml
@@ -127,7 +127,7 @@
 						HorizontalAlignment="Center">
 
 				<!-- Progress Ring -->
-				<ProgressRing IsActive="{Binding LoadingSuccess, Converter={StaticResource BoolToInvertBool}}"
+				<ProgressRing IsActive="True"
 							  Foreground="{StaticResource Color03Brush}"
 							  Height="20"
 							  Width="20"
@@ -225,7 +225,7 @@
 						  ItemTemplate="{StaticResource SprintComboBoxItemTemplate}"
 						  Height="{StaticResource LargeComboBoxHeight}"
 						  xamarin:DeferLoadStrategy="Lazy" />
-				
+
 				<!-- No Sprint State -->
 				<Grid Visibility="{Binding Iterations.Result, Converter={StaticResource EnumerableHasAnyToCollapsed}, FallbackValue=Collapsed }"
 					  Background="{StaticResource Color02Brush}"
@@ -251,7 +251,7 @@
 					  BorderThickness="0,0,0,1">
 
 					<!-- Progress Ring -->
-					<ProgressRing IsActive="{Binding Iterations.IsExecuting}"
+					<ProgressRing IsActive="True"
 								  Foreground="{StaticResource Color03Brush}"
 								  Height="20"
 								  Width="20"
@@ -267,7 +267,7 @@
 						  IsItemClickEnabled="True"
 						  ItemClick="ListView_ItemClick"
 						  Grid.Row="1"
-						  Padding="0,0,0,80"/>
+						  Padding="0,0,0,80" />
 
 				<!-- Empty List Message -->
 				<TextBlock Text="No work items in this iteration"
@@ -275,19 +275,19 @@
 						   Style="{StaticResource Typo15}"
 						   Margin="16,12"
 						   Grid.Row="1" />
-		
+
 				<!-- Error state for work items list -->
 				<Grid Visibility="{Binding IterationWorkItems.IsFaulted, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-				      Background="{StaticResource Color07Brush}"
-				      Grid.Row="1">
+					  Background="{StaticResource Color07Brush}"
+					  Grid.Row="1">
 
 					<!-- Message -->
 					<TextBlock Text="{Binding IterationWorkItems.IsInternetFaulted, Converter={StaticResource BoolToCustomString}}"
-					           Style="{StaticResource Typo10}"
-					           HorizontalAlignment="Center"
-					           VerticalAlignment="Center"
-					           TextAlignment="Center"
-							   Margin="25,0,25,24"/>
+							   Style="{StaticResource Typo10}"
+							   HorizontalAlignment="Center"
+							   VerticalAlignment="Center"
+							   TextAlignment="Center"
+							   Margin="25,0,25,24" />
 				</Grid>
 
 				<!-- Loading State -->
@@ -298,7 +298,7 @@
 								HorizontalAlignment="Center">
 
 						<!-- Progress Ring -->
-						<ProgressRing IsActive="{Binding IterationWorkItems.IsExecuting}"
+						<ProgressRing IsActive="True"
 									  Foreground="{StaticResource Color03Brush}"
 									  Height="20"
 									  Width="20"
@@ -311,12 +311,12 @@
 								   Style="{StaticResource Typo08}" />
 					</StackPanel>
 				</Grid>
-				
+
 				<!-- ComboBox Popup BG 1 -->
 				<Grid Visibility="{Binding IsDropDownOpen, ElementName=TeamsComboBox, Converter={StaticResource TrueToVisible}}"
 					  Background="Black"
 					  Opacity="0.6"
-					  Grid.RowSpan="2"/>
+					  Grid.RowSpan="2" />
 
 				<!-- ComboBox Popup BG 2 -->
 				<Grid Visibility="{Binding IsDropDownOpen, ElementName=IterationsComboBox, Converter={StaticResource TrueToVisible}}"
@@ -395,7 +395,7 @@
 
 				<!-- Error state for member listview -->
 				<Grid Visibility="{Binding TeamMembers.IsFaulted, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-				      Background="{StaticResource Color07Brush}">
+					  Background="{StaticResource Color07Brush}">
 
 					<!-- Message -->
 					<TextBlock Text="{Binding TeamMembers.IsInternetFaulted, Converter={StaticResource BoolToCustomString}}"
@@ -405,7 +405,7 @@
 							   TextAlignment="Center"
 							   Margin="50,0,50,48" />
 				</Grid>
-				
+
 
 				<!-- Loading State -->
 				<Grid Visibility="{Binding TeamMembers.IsExecuting, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
@@ -414,7 +414,7 @@
 								HorizontalAlignment="Center">
 
 						<!-- Progress Ring -->
-						<ProgressRing IsActive="{Binding TeamMembers.IsExecuting}"
+						<ProgressRing IsActive="True"
 									  Foreground="{StaticResource Color03Brush}"
 									  Height="20"
 									  Width="20"


### PR DESCRIPTION
- Projects and Organizations are now refreshed only when user navigates to the concerned page in order to keep the listview position when navigating back to these pages (navigation is also smoother).
- Removed unecessary bindings on progress ring as parent view already binds to. 