### PR TITLE
Added menu platform specific markup for wasm and win

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/OrganizationListPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/OrganizationListPage.xaml
@@ -5,7 +5,9 @@
 	  xmlns:uc="using:Uno.AzureDevOps.Views.Controls"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  mc:Ignorable="">
+	  xmlns:wasm="http:/uno.ui/wasm"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  mc:Ignorable="wasm">
 
 	<Grid Background="{StaticResource Color02Brush}"
 		  toolkit:VisibleBoundsPadding.PaddingMask="Left,Right">
@@ -32,10 +34,14 @@
 								Value="300" />
 						<Setter Target="LargeViewNavigation.Visibility"
 								Value="Visible" />
-						<Setter Target="LargeViewNavigation.(Grid.Row)"
+						<wasm:Setter Target="LargeViewNavigation.(Grid.Row)"
 								Value="0" />
-						<Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+						<wasm:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
 								Value="2" />
+						<win:Setter Target="LargeViewNavigation.(Grid.Row)"
+									 Value="0" />
+						<win:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+									 Value="2" />
 						<Setter Target="HamburgerButton.Visibility"
 								Value="Collapsed" />
 						<Setter Target="ContentView.(Grid.Column)"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectListPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectListPage.xaml
@@ -4,7 +4,8 @@
 	  xmlns:local="using:Uno.AzureDevOps.Views.Content"
 	  xmlns:uc="using:Uno.AzureDevOps.Views.Controls"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:wasm="http://nventive.com/wasm"
+	  xmlns:wasm="http:/uno.ui/wasm"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  mc:Ignorable="wasm">
 
@@ -82,10 +83,14 @@
 								Value="300" />
 						<Setter Target="LargeViewNavigation.Visibility"
 								Value="Visible" />
-						<Setter Target="LargeViewNavigation.(Grid.Row)"
-								Value="0" />
-						<Setter Target="LargeViewNavigation.(Grid.RowSpan)"
-								Value="2" />
+						<wasm:Setter Target="LargeViewNavigation.(Grid.Row)"
+									 Value="0" />
+						<wasm:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+									 Value="2" />
+						<win:Setter Target="LargeViewNavigation.(Grid.Row)"
+									Value="0" />
+						<win:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+									Value="2" />
 						<Setter Target="HamburgerButton.Visibility"
 								Value="Collapsed" />
 						<Setter Target="ContentView.(Grid.Column)"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProjectPage.xaml
@@ -1,12 +1,13 @@
 ﻿<Page x:Class="Uno.AzureDevOps.Views.Content.ProjectPage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:xamarin="http://nventive.com/xamarin"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  xmlns:uc="using:Uno.AzureDevOps.Views.Controls"
-	  mc:Ignorable="xamarin">
+	  xmlns:wasm="http:/uno.ui/wasm"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  mc:Ignorable="xamarin wasm">
 
 	<Page.Resources>
 
@@ -118,10 +119,14 @@
 								Value="Collapsed" />
 						<Setter Target="ContentView.(Grid.Column)"
 								Value="1" />
-						<Setter Target="LargeViewNavigation.(Grid.Row)"
-								Value="0" />
-						<Setter Target="LargeViewNavigation.(Grid.RowSpan)"
-								Value="2" />
+						<wasm:Setter Target="LargeViewNavigation.(Grid.Row)"
+									 Value="0" />
+						<wasm:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+									 Value="2" />
+						<win:Setter Target="LargeViewNavigation.(Grid.Row)"
+									Value="0" />
+						<win:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
+									Value="2" />
 						<Setter Target="MainGridViewColumn_1.Width"
 								Value="Auto" />
 						<Setter Target="MainGridViewColumn_2.Width"


### PR DESCRIPTION
- This PR fixes the bug on iPad/Android tablet of the menu going under the navigation bar. This behavior is now specific to WASM and UWP. 