### PR TITLE
Fixed loop issue with deep navigation

### DIFF
--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/OrganizationListPageViewModel.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/OrganizationListPageViewModel.cs
@@ -10,6 +10,7 @@ using Uno.AzureDevOps.Business.VSTS;
 using Uno.AzureDevOps.Client;
 using Uno.AzureDevOps.Framework.Navigation;
 using Uno.AzureDevOps.Framework.Tasks;
+using Uno.AzureDevOps.Views.Content;
 
 namespace Uno.AzureDevOps.Presentation
 {
@@ -28,7 +29,7 @@ namespace Uno.AzureDevOps.Presentation
 			_vstsRepository = SimpleIoc.Default.GetInstance<IVSTSRepository>();
 			_userPreferencesService = SimpleIoc.Default.GetInstance<IUserPreferencesService>();
 
-			ToProjectListPage = new RelayCommand<AccountData>(account => _navigationService.ToProjectListPage(account));
+			ToProjectListPage = new RelayCommand<AccountData>(account => _navigationService.NavigateToAndClearStack(nameof(ProjectListPage), account));
 
 			ToProfilePage = new RelayCommand(() => _navigationService.ToProfilePage());
 

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/SideMenuViewModel.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Shared/Presentation/SideMenuViewModel.cs
@@ -13,6 +13,7 @@ using Uno.AzureDevOps.Client;
 using Uno.AzureDevOps.Framework.AppVersion;
 using Uno.AzureDevOps.Framework.Navigation;
 using Uno.AzureDevOps.Framework.Tasks;
+using Uno.AzureDevOps.Views.Content;
 
 namespace Uno.AzureDevOps.Presentation
 {
@@ -39,8 +40,8 @@ namespace Uno.AzureDevOps.Presentation
 
 			ToProfilePage = new RelayCommand(() => _navigationService.ToProfilePage());
 			ToAboutPage = new RelayCommand(() => _navigationService.ToAboutPage());
-			ToProjectListPage = new RelayCommand(() => _navigationService.ToProjectListPage(_account));
-			ToOrganizationListPage = new RelayCommand(() => _navigationService.ToOrganizationListPage());
+			ToOrganizationListPage = new RelayCommand(() => _navigationService.NavigateToAndClearStack(nameof(OrganizationListPage)));
+			ToProjectListPage = new RelayCommand(() => _navigationService.NavigateToAndClearStack(nameof(ProjectListPage), Account));
 
 			AppVersion = VersionHelper.GetAppVersionWithBuildNumber;
 		}

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/AboutPage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/AboutPage.xaml
@@ -57,8 +57,6 @@
 									Value="0" />
 						<win:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
 									Value="2" />
-						<Setter Target="HamburgerButton.Visibility"
-								Value="Collapsed" />
 						<Setter Target="ContentView.(Grid.Column)"
 								Value="1" />
 						<Setter Target="MainGridViewColumn_1.Width"
@@ -88,12 +86,6 @@
 					Grid.ColumnSpan="2"
 					beh:FullscreenSideMenuBehavior.IsFullscreenMenu="{Binding IsFullscreenMenu, ElementName=LargeViewNavigation}"
 					beh:FullscreenSideMenuBehavior.MenuVisibility="{Binding MenuVisibility, ElementName=LargeViewNavigation}">
-			<CommandBar.PrimaryCommands>
-				<AppBarButton x:Name="HamburgerButton"
-						  Click="HamburgerButton_Click"
-						  Style="{StaticResource BurgerMenuButtonStyle}">
-			</AppBarButton>
-			</CommandBar.PrimaryCommands>
 		</CommandBar>
 
 		<ScrollViewer x:Name="ContentView" Grid.Row="1">
@@ -208,11 +200,5 @@
 					 Grid.Row="1"
 					 Grid.RowSpan="1"
 					 HorizontalAlignment="Stretch" />
-		<!-- Close Button -->
-		<Border toolkit:VisibleBoundsPadding.PaddingMask="Top">
-			<Button Style="{StaticResource MenuCloseButtonStyle}"
-					Click="HamburgerButton_Click"
-					Visibility="{Binding Visibility, ElementName=CommandBarView, Converter={StaticResource InverseVisible}}" />
-		</Border>
 	</Grid>
 </Page>

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/AboutPage.xaml.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/AboutPage.xaml.cs
@@ -9,31 +9,12 @@ namespace Uno.AzureDevOps.Views.Content
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	[SuppressMessage("", "CA1801", Justification = "Event handler")]
 	public sealed partial class AboutPage : Page
 	{
 		public AboutPage()
 		{
 			this.InitializeComponent();
 			this.DataContext = new AboutPageViewModel();
-		}
-
-		private void HamburgerButton_Click(object sender, RoutedEventArgs e)
-		{
-			if (LargeViewNavigation.MenuVisibility == Visibility.Collapsed)
-			{
-				LargeViewNavigation.MenuVisibility = Visibility.Visible;
-				LargeViewNavigation.SetValue(Grid.ColumnProperty, 0);
-				LargeViewNavigation.SetValue(Grid.RowProperty, 0);
-				LargeViewNavigation.SetValue(Grid.RowSpanProperty, 2);
-				ContentView.SetValue(Grid.ColumnProperty, 0);
-			}
-			else
-			{
-				LargeViewNavigation.MenuVisibility = Visibility.Collapsed;
-				LargeViewNavigation.SetValue(Grid.RowProperty, 1);
-				LargeViewNavigation.SetValue(Grid.RowSpanProperty, 1);
-			}
 		}
 	}
 }

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml
@@ -49,8 +49,6 @@
 									Value="0" />
 						<win:Setter Target="LargeViewNavigation.(Grid.RowSpan)"
 									Value="2" />
-						<Setter Target="HamburgerButton.Visibility"
-								Value="Collapsed" />
 						<Setter Target="ContentView.(Grid.Column)"
 								Value="1" />
 						<Setter Target="MainGridViewColumn_1.Width"
@@ -69,13 +67,6 @@
 					Grid.ColumnSpan="2"
 					beh:FullscreenSideMenuBehavior.IsFullscreenMenu="{Binding IsFullscreenMenu, ElementName=LargeViewNavigation}"
 					beh:FullscreenSideMenuBehavior.MenuVisibility="{Binding MenuVisibility, ElementName=LargeViewNavigation}">
-			<!-- Hamburger Button  -->
-			<CommandBar.PrimaryCommands>
-			<AppBarButton x:Name="HamburgerButton"
-						  Click="HamburgerButton_Click"
-						  Style="{StaticResource BurgerMenuButtonStyle}">
-			</AppBarButton>
-			</CommandBar.PrimaryCommands>
 		</CommandBar>
 
 		<Grid Grid.Row="1"
@@ -194,12 +185,5 @@
 					 Grid.Row="1"
 					 Grid.RowSpan="1"
 					 HorizontalAlignment="Stretch" />
-
-		<!-- Close Button -->
-		<Border toolkit:VisibleBoundsPadding.PaddingMask="Top">
-			<Button Style="{StaticResource MenuCloseButtonStyle}"
-					Click="HamburgerButton_Click"
-					Visibility="{Binding Visibility, ElementName=CommandBarView, Converter={StaticResource InverseVisible}}" />
-		</Border>
 	</Grid>
 </Page>

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml.cs
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Content/ProfilePage.xaml.cs
@@ -9,31 +9,12 @@ namespace Uno.AzureDevOps.Views.Content
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	[SuppressMessage("", "CA1801", Justification = "Event handler")]
 	public sealed partial class ProfilePage : Page
 	{
 		public ProfilePage()
 		{
 			InitializeComponent();
 			DataContext = new ProfilePageViewModel();
-		}
-
-		private void HamburgerButton_Click(object sender, RoutedEventArgs e)
-		{
-			if (LargeViewNavigation.MenuVisibility == Visibility.Collapsed)
-			{
-				LargeViewNavigation.MenuVisibility = Visibility.Visible;
-				LargeViewNavigation.SetValue(Grid.ColumnProperty, 0);
-				LargeViewNavigation.SetValue(Grid.RowProperty, 0);
-				LargeViewNavigation.SetValue(Grid.RowSpanProperty, 2);
-				ContentView.SetValue(Grid.ColumnProperty, 0);
-			}
-			else
-			{
-				LargeViewNavigation.MenuVisibility = Visibility.Collapsed;
-				LargeViewNavigation.SetValue(Grid.RowProperty, 1);
-				LargeViewNavigation.SetValue(Grid.RowSpanProperty, 1);
-			}
 		}
 	}
 }

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/Menu/SideMenu.xaml
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Controls/Menu/SideMenu.xaml
@@ -1,7 +1,6 @@
 ﻿<UserControl x:Class="Uno.AzureDevOps.Views.Controls.SideMenu"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:local="using:Uno.AzureDevOps.Views.Controls.Menu"
 			 xmlns:behaviors="using:Uno.AzureDevOps.Views.Behaviors"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Uno.AzureDevOps.Views.projitems
+++ b/src/Uno.AzureDevOps/Uno.AzureDevOps.Views/Uno.AzureDevOps.Views.projitems
@@ -183,6 +183,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Styles\Controls\ToggleButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Styles\Controls\_Controls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
- Removed the hamburger menu from About & Profile page. 
- When navigating to organizations and projects list, clearing the stack to avoid an endless loop with navigation stack. 